### PR TITLE
chore: correct the browser field in the package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "email": "contact@niketpathak.com",
     "url": "https://niketpathak.com"
   },
-  "browser": "dist/localstorage-slim.min.js",
+  "browser": "dist/localstorage-slim.js",
   "main": "dist/localstorage-slim.js",
   "types": "./dist/ls.d.ts",
   "repository": {


### PR DESCRIPTION
When I use vite to build my project, it will output the following error message:

```console
$ vite
 > node_modules/vite/dist/node/chunks/dep-972722fa.js:39166:10: error: [plugin: vite:dep-scan] Failed to resolve entry for package "localstorage-slim". The package may have incorrect main/module/exports specified in its package.json: Failed to resolve entry for package "localstorage-slim". The package may have incorrect main/module/exports specified in its package.json.
    39166 │     throw new Error(`Failed to resolve entry for package "${id}". ` +
```

I found that the `node_modules/localstorage-slim/dist/localstorage-slim.min.js` file did not exist, so I corrected the browser field in the package.json file.
