### PR TITLE
Fix supportLS function always returning true

### DIFF
--- a/src/ls.ts
+++ b/src/ls.ts
@@ -17,12 +17,12 @@ const supportsLS = (): boolean => {
     if (!localStorage) {
       hasLS = false;
     }
+    hasLS = true;
   } catch (e) {
     // some browsers throw an error if you try to access local storage (e.g. brave browser)
     // and some like Safari do not allow access to LS in incognito mode
     hasLS = false;
   }
-  hasLS = true;
 
   // flush once on init
   flush();

--- a/src/ls.ts
+++ b/src/ls.ts
@@ -12,12 +12,12 @@ let hasLS: boolean;
 
 const supportsLS = (): boolean => {
   if (hasLS !== undefined) return hasLS;
+  hasLS = true;
 
   try {
     if (!localStorage) {
       hasLS = false;
     }
-    hasLS = true;
   } catch (e) {
     // some browsers throw an error if you try to access local storage (e.g. brave browser)
     // and some like Safari do not allow access to LS in incognito mode


### PR DESCRIPTION
The `supportLS` function currently returns `true` even for browsers that do not support `localstorage`.

This PR fixes the issue by moving the `hasLS = true` assignment inside the try block, to avoid overwriting the value of the `hasLS` variable in the cases where there is no browser support.

Fixes #11