### PR TITLE
🐛 Fix a bug in ls.flush()

### DIFF
--- a/src/ls.ts
+++ b/src/ls.ts
@@ -135,7 +135,7 @@ const flush = (force = false): void => {
       item = JSON.parse(str || '');
     } catch {
       // Some packages write strings to localStorage that are not converted by JSON.stringify(), so we need to ignore it
-      return;
+      continue;
     }
     // flush only if ttl was set and is expired or is forced to clear
     if (isObject(item) && APX in item && (Date.now() > item.ttl || force)) {


### PR DESCRIPTION
When using `localstorage-slim` alongside the vanilla `localStorage`, situations may arise where some objects in `localStorage` do not fit the format expected by `localstorage-slim`.

When using `flush()`, there was a bug where, if `flush()` encountered a non-`localstorage-slim`, object, it would `return`, skipping all following entries, where some might be `localstorage-slim` objects.

The bug is fixed by replacing the `return` statement by a `continue` statement, ensuring *all* objects in `localStorage` are checked to be flushed.

<!-- PULL REQUEST TEMPLATE -->
<!-- Update "[ ]" to "[x]" to check a box (space sensitive) -->

**What kind of change does this PR introduce?** <!-- Check at least one -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** <!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications: -->

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch (or `v[X]` branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: [#xxx]`, where "xxx" is the issue number)
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/digitalfortress-tech/localstorage-slim#readme) <!-- for faster update click on "Suggest an edit on GitHub" at bottom of page --> or explained in the PR's description.


**Other information:**